### PR TITLE
Better stamp previews

### DIFF
--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -482,6 +482,11 @@ void GameController::TransformSave(matrix2d transform)
 	gameModel->SetPlaceSave(gameModel->GetPlaceSave());
 }
 
+void GameController::ReRenderSave()
+{
+	gameModel->SetPlaceSave(gameModel->GetPlaceSave());
+}
+
 void GameController::ToolClick(int toolSelection, ui::Point point)
 {
 	Simulation * sim = gameModel->GetSimulation();

--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -484,7 +484,8 @@ void GameController::TransformSave(matrix2d transform)
 
 void GameController::ReRenderSave()
 {
-	gameModel->SetPlaceSave(gameModel->GetPlaceSave());
+	if (gameView->GetSelectMode() == SelectMode::PlaceSave)
+		gameView->NotifyPlaceSaveChanged(gameModel);
 }
 
 void GameController::ToolClick(int toolSelection, ui::Point point)

--- a/src/gui/game/GameController.h
+++ b/src/gui/game/GameController.h
@@ -177,6 +177,7 @@ public:
 	bool AreParticlesInSubframeOrder();
 	void TranslateSave(ui::Point point);
 	void TransformSave(matrix2d transform);
+	void ReRenderSave();
 	bool MouseInZoom(ui::Point position);
 	ui::Point PointTranslate(ui::Point point);
 	ui::Point NormaliseBlockCoord(ui::Point point);

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1468,6 +1468,7 @@ void GameView::OnKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl,
 				c->SetPaused(true);
 				c->SetActiveMenu(SC_DECO);
 			}
+		if (selectMode == PlaceSave) c->ReRenderSave();
 		break;
 	case SDL_SCANCODE_Y:
 		if (ctrl)
@@ -1902,7 +1903,7 @@ void GameView::NotifyPlaceSaveChanged(GameModel * sender)
 	placeSaveOffset = ui::Point(0, 0);
 	if(sender->GetPlaceSave())
 	{
-		placeSaveThumb = SaveRenderer::Ref().Render(sender->GetPlaceSave(), true, true, sender->GetRenderer());
+		placeSaveThumb = SaveRenderer::Ref().Render(sender->GetPlaceSave(), sender->GetRenderer()->decorations_enable, true, sender->GetRenderer());
 		selectMode = PlaceSave;
 		selectPoint2 = mousePosition;
 	}

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1468,7 +1468,7 @@ void GameView::OnKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl,
 				c->SetPaused(true);
 				c->SetActiveMenu(SC_DECO);
 			}
-		if (selectMode == PlaceSave) c->ReRenderSave();
+		c->ReRenderSave();
 		break;
 	case SDL_SCANCODE_Y:
 		if (ctrl)
@@ -1611,7 +1611,7 @@ void GameView::OnKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl,
 	else if (key >= '0' && key <= '9')
 	{
 		c->LoadRenderPreset(key-'0');
-		if (selectMode == PlaceSave) c->ReRenderSave();
+		c->ReRenderSave();
 	}
 }
 

--- a/src/gui/game/GameView.cpp
+++ b/src/gui/game/GameView.cpp
@@ -1610,6 +1610,7 @@ void GameView::OnKeyPress(int key, int scan, bool repeat, bool shift, bool ctrl,
 	else if (key >= '0' && key <= '9')
 	{
 		c->LoadRenderPreset(key-'0');
+		if (selectMode == PlaceSave) c->ReRenderSave();
 	}
 }
 

--- a/src/lua/LuaScriptInterface.cpp
+++ b/src/lua/LuaScriptInterface.cpp
@@ -2455,6 +2455,7 @@ int LuaScriptInterface::renderer_renderModes(lua_State * l)
 			lua_pop(l, 1);
 		}
 		luacon_ren->SetRenderMode(renderModes);
+		luacon_controller->ReRenderSave();
 		return 0;
 	}
 	else
@@ -2488,6 +2489,7 @@ int LuaScriptInterface::renderer_displayModes(lua_State * l)
 			lua_pop(l, 1);
 		}
 		luacon_ren->SetDisplayMode(displayModes);
+		luacon_controller->ReRenderSave();
 		return 0;
 	}
 	else
@@ -2511,6 +2513,7 @@ int LuaScriptInterface::renderer_colourMode(lua_State * l)
 	{
 		luaL_checktype(l, 1, LUA_TNUMBER);
 		luacon_ren->SetColourMode(lua_tointeger(l, 1));
+		luacon_controller->ReRenderSave();
 		return 0;
 	}
 	else
@@ -2526,6 +2529,7 @@ int LuaScriptInterface::renderer_decorations(lua_State * l)
 	if(args)
 	{
 		luacon_ren->decorations_enable = lua_toboolean(l, 1);
+		luacon_controller->ReRenderSave();
 		return 0;
 	}
 	else


### PR DESCRIPTION
Stamp previews now correctly reflect the render styles and decoration layer on keypresses. It also works using the lua interface, incase anyone uses the custom render presets script.